### PR TITLE
Add MessageStream option to Email.

### DIFF
--- a/email.go
+++ b/email.go
@@ -35,6 +35,8 @@ type Email struct {
 	Attachments []Attachment `json:",omitempty"`
 	// Metadata: metadata
 	Metadata map[string]string `json:",omitempty"`
+	// MessageStream: MessageStream will default to the outbound message stream ID (Default Transactional Stream) if no message stream ID is provided.
+	MessageStream string `json:",omitempty"`
 }
 
 // Header - an email header


### PR DESCRIPTION
Hi there!

Your fork is one of the only ones being maintained. I found it useful in my project, but it was missing the _MessageStream_ option in the Email. Here is a small contribution to add that option.

It is the last bullet point in here (under JSON message format):
https://postmarkapp.com/developer/user-guide/send-email-with-api/send-a-single-email

It helps the emails to land under the correct "stream categories" by this message stream ID.