### PR TITLE
Add option to disable link tracking

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -178,6 +178,8 @@ type TemplatedEmail struct {
 	Headers []Header `json:",omitempty"`
 	// TrackOpens: Activate open tracking for this email.
 	TrackOpens bool `json:",omitempty"`
+	// TrackLinks: Activate link tracking. Possible options: "None", "HtmlAndText", "HtmlOnly", "TextOnly".
+	TrackLinks string `json:",omitempty"`
 	// Attachments: List of attachments
 	Attachments []Attachment `json:",omitempty"`
 	// MessageStream: MessageStream will default to the outbound message stream ID (Default Transactional Stream) if no message stream ID is provided.

--- a/templates_test.go
+++ b/templates_test.go
@@ -231,6 +231,7 @@ var testTemplatedEmail = TemplatedEmail{
 		},
 	},
 	TrackOpens: true,
+	TrackLinks: "HtmlAndText",
 	Attachments: []Attachment{
 		{
 			Name:        "readme.txt",


### PR DESCRIPTION
Original doc: https://postmarkapp.com/developer/api/templates-api

This allows the developers to decide whether they want to track their links.

When the link tracker is enabled: all original links are masked which sometimes creates suspicions among the end-users.

When the link tracker is disabled: the end-users can see the original links.