### PR TITLE
suppresions API fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ client.HTTPClient = urlfetch.Client(ctx)
     * [x] `DELETE /templates/:id`
     * [x] `POST /templates/validate`
 * [x] Suppressions
-    * [x] `GET /suppressions/:id`
+    * [x] `GET /suppressions/dump`
+    * [x] `POST /suppressions` 
+    * [x] `POST /suppressions/delete`
 * [x] Servers
     * [x] `GET /servers/:id`
     * [x] `PUT /servers/:id`

--- a/suppressions.go
+++ b/suppressions.go
@@ -92,6 +92,11 @@ type updateSuppressionsResponse struct {
 	Suppressions []SuppressionResponse
 }
 
+// suppressionsRequest - A message to send to the Postmark server for creating or deleting suppressions
+type suppressionsRequest struct {
+	Suppressions []Suppression
+}
+
 // GetSuppressions fetches email addresses in the list of suppression dump on the server
 // It returns a Suppressions slice, and any error that occurred
 // https://postmarkapp.com/developer/api/suppressions-api#suppression-dump
@@ -129,7 +134,7 @@ func (client *Client) CreateSuppressions(
 	err := client.doRequest(ctx, parameters{
 		Method:    http.MethodPost,
 		Path:      fmt.Sprintf("message-streams/%s/suppressions", streamID),
-		Payload:   suppressions,
+		Payload:   suppressionsRequest{Suppressions: suppressions},
 		TokenType: serverToken,
 	}, &res)
 	return res.Suppressions, err
@@ -146,7 +151,7 @@ func (client *Client) DeleteSuppressions(
 	err := client.doRequest(ctx, parameters{
 		Method:    http.MethodPost,
 		Path:      fmt.Sprintf("message-streams/%s/suppressions/delete", streamID),
-		Payload:   suppressions,
+		Payload:   suppressionsRequest{Suppressions: suppressions},
 		TokenType: serverToken,
 	}, &res)
 	return res.Suppressions, err


### PR DESCRIPTION
This PR corrects the formatting issues with delete and create suppression requests. I tested it against the Postmark API, and it appears to be functioning properly.