### PR TITLE
Set `Request.GetBody` in `doRequest`

### DIFF
--- a/postmark.go
+++ b/postmark.go
@@ -73,7 +73,7 @@ func (client *Client) doRequest(ctx context.Context, opts parameters, dst interf
 		req.GetBody = func() (io.ReadCloser, error) {
 			return io.NopCloser(bytes.NewBuffer(payloadData)), nil
 		}
-        }
+	}
 
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")

--- a/postmark.go
+++ b/postmark.go
@@ -70,7 +70,10 @@ func (client *Client) doRequest(ctx context.Context, opts parameters, dst interf
 			return
 		}
 		req.Body = io.NopCloser(bytes.NewBuffer(payloadData))
-	}
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewBuffer(payloadData)), nil
+		}
+        }
 
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")


### PR DESCRIPTION
I was running into an issue periodically:
```
Post "https://api.postmarkapp.com/email": http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
```
when trying to send an email through this library.

Based on research (https://github.com/golang/go/issues/62453, https://github.com/stripe/stripe-go/pull/711/files, https://ragoragino.dev/blog/softwareengineering/2022-02-05-goaway-test/index.html) it looks like Golang attempts a retry when receiving `GOAWAY` from a server. [https://sourcegraph.com/github.com/golang/net/-/commit/cffdcf672aee934982473246bc7e9a8ba446aa9b?visible=2](Go code here)

But, this means that we need to define a `GetBody` function in the request to allow the http2 package to retry. Since the payload we have here is static, we can set it equal to the `Body`. 

I tested this by patching my dependency with this new version, and my emails still send, so I think this at least won't break anything.