### PR TITLE
fix: parse inbound message using `mail.ParseDate`

### DIFF
--- a/messages_inbound.go
+++ b/messages_inbound.go
@@ -3,6 +3,7 @@ package postmark
 import (
 	"context"
 	"fmt"
+	"net/mail"
 	"net/url"
 	"time"
 )
@@ -52,9 +53,8 @@ type InboundMessage struct {
 }
 
 // Time returns a parsed time.Time struct
-// Inbound messages return as RFC1123Z strangely
 func (x InboundMessage) Time() (time.Time, error) {
-	return time.Parse(time.RFC1123Z, x.Date)
+	return mail.ParseDate(x.Date)
 }
 
 // GetInboundMessage fetches a specific inbound message via serverID


### PR DESCRIPTION
For some reason, the date formatting isn't consistent in emails.
When receiving an email, the format can be as follows:
- Thu, 28 Nov 2024 12:50:03 +0000
- Thu, 28 Nov 2024 12:50:03 +0000 (UTC)

---

When using the `RFC1123Z` format, the first one can be parsed, but the second one throws an error.
There's a solution for this, which is [mail.ParseDate](https://pkg.go.dev/net/mail#ParseDate), which parses both dates flawless. And thus, this'd be a better solution to parse the dates using the helper function `Time()`.