### PR TITLE
fix(inbound): add json tag to inboundMessagesResponse to match postmark's api

### DIFF
--- a/messages_inbound.go
+++ b/messages_inbound.go
@@ -69,8 +69,8 @@ func (client *Client) GetInboundMessage(ctx context.Context, messageID string) (
 }
 
 type inboundMessagesResponse struct {
-	TotalCount int64
-	Messages   []InboundMessage
+	TotalCount int64            `json:"TotalCount"`
+	Messages   []InboundMessage `json:"InboundMessages"`
 }
 
 // GetInboundMessages fetches a list of inbound message on the server


### PR DESCRIPTION
The inbound api returns "InboundMessages" not "Messages"

see
https://postmarkapp.com/developer/api/messages-api#inbound-message-search